### PR TITLE
Add nickname line and align nickname to right

### DIFF
--- a/py/borderless_showcase.py
+++ b/py/borderless_showcase.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Literal
 from photoshop.api._artlayer import ArtLayer
 from photoshop.api._layerSet import LayerSet
 
-from plugins.proxy_stuff.py.planeswalker import LAYER_NAMES
+from .planeswalker import LAYER_NAMES
 from src import CFG
 from src.enums.adobe import Dimensions
 from src.enums.layers import LAYERS
@@ -220,6 +220,10 @@ class BorderlessShowcase(BorderlessVectorTemplate, PlaneswalkerMod):
             [_shape_group, LAYERS.NAME],
         ):
             layers.append(layer)
+
+        # Add nickname pinlines if required
+        if self.is_nickname:
+            layers.append(getLayerSet(LAYERS.NICKNAME, _shape_group))
 
         if self.is_planeswalker:
             if layer := getLayerSet(self.size, _shape_group):

--- a/py/planeswalker.py
+++ b/py/planeswalker.py
@@ -13,7 +13,7 @@ from photoshop.api._artlayer import ArtLayer
 from photoshop.api._layerSet import LayerSet
 
 import src.helpers as psd
-from plugins.proxy_stuff.py.helpers import (
+from .helpers import (
     create_vector_mask_from_shape,
     subtract_front_shape,
 )

--- a/py/templates.py
+++ b/py/templates.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from photoshop.api._artlayer import ArtLayer
-from plugins.proxy_stuff.py.borderless_showcase import BorderlessShowcase
-from plugins.proxy_stuff.py.planeswalker import PlaneswalkerBorderlessVector
-from plugins.proxy_stuff.py.restore import load_backup_artwork
+from .borderless_showcase import BorderlessShowcase
+from .planeswalker import PlaneswalkerBorderlessVector
+from .restore import load_backup_artwork
 from src.utils.adobe import ReferenceLayer
 
 


### PR DESCRIPTION
This PR adjusts nickname handling for the borderless showcase template.

I also changed the local imports to be relative because they weren't working for me, this is the same pattern as the built in plugins so I think this is correct.

Here is the updated psd - I realigned the nickname text box and added a Nickname typeline layer.
[borderless-showcase.zip](https://github.com/user-attachments/files/18950606/borderless-showcase.zip)
